### PR TITLE
Client.list_dataset_tables(dataset) has been deprecated in favor of Client.list_tables(dataset)

### DIFF
--- a/pybigquery/sqlalchemy_bigquery.py
+++ b/pybigquery/sqlalchemy_bigquery.py
@@ -189,7 +189,7 @@ class BigQueryDialect(DefaultDialect):
         for d in datasets:
             if schema is not None and d.dataset_id != schema:
                 continue
-            tables = connection.connection._client.list_dataset_tables(d.reference)
+            tables = connection.connection._client.list_tables(d.reference)
             for t in tables:
                 result.append(d.dataset_id + '.' + t.table_id)
         return result


### PR DESCRIPTION
Hi,

There has been a method name change. Currently the master doesn't work with e.g. Superset. There was also an error in the docs that has been fixed:
https://github.com/GoogleCloudPlatform/google-cloud-python/issues/4712