### PR TITLE
Fix autogenerated metrics

### DIFF
--- a/pybigquery/sqlalchemy_bigquery.py
+++ b/pybigquery/sqlalchemy_bigquery.py
@@ -74,6 +74,9 @@ class BigQueryCompiler(SQLCompiler):
         result = super(BigQueryCompiler, self).visit_label(*args, **kwargs)
         return result
 
+    def visit_column(self, column, add_to_result_map=None, include_table=False, **kwargs):
+        return super(BigQueryCompiler, self).visit_column(column, add_to_result_map, False, **kwargs)
+
 
 class BigQueryDialect(DefaultDialect):
     name = 'bigquery'

--- a/pybigquery/sqlalchemy_bigquery.py
+++ b/pybigquery/sqlalchemy_bigquery.py
@@ -11,6 +11,7 @@ from sqlalchemy import types, util
 from sqlalchemy.sql.compiler import SQLCompiler, IdentifierPreparer
 from sqlalchemy.engine.default import DefaultDialect, DefaultExecutionContext
 from sqlalchemy.engine.base import Engine
+from sqlalchemy.sql.schema import Column
 
 
 class UniversalSet(object):
@@ -67,15 +68,18 @@ class BigQueryExecutionContext(DefaultExecutionContext):
 
 
 class BigQueryCompiler(SQLCompiler):
+    def __init__(self, dialect, statement, column_keys=None,
+                 inline=False, **kwargs):
+        if isinstance(statement, Column):
+             kwargs['compile_kwargs'] = util.immutabledict({'include_table': False})
+        super(BigQueryCompiler, self).__init__(dialect, statement, column_keys, inline, **kwargs)
+
     def visit_label(self, *args, **kwargs):
         # Use labels in GROUP BY clause
         if len(kwargs) == 0 or len(kwargs) == 1:
             kwargs['render_label_as_label'] = args[0]
         result = super(BigQueryCompiler, self).visit_label(*args, **kwargs)
         return result
-
-    def visit_column(self, column, add_to_result_map=None, include_table=False, **kwargs):
-        return super(BigQueryCompiler, self).visit_column(column, add_to_result_map, False, **kwargs)
 
 
 class BigQueryDialect(DefaultDialect):


### PR DESCRIPTION
Auto generated sum/avg metrics in superset shows sum/avg expression as 
<pre>
AVG(`dataset`.`table`.`column`)
SUM(`dataset`.`table`.`column`)
</pre>
which is syntactically wrong in BQ.

To fix it have overwritten the visit_column method of SQLCompiler in BigQueryCompiler to set include_table parameter which is true by default to false. When this is done, the sum expression becomes
<pre>
SUM(`column`) which is correct.
</pre>

Could you please check if the fix is good and merge it.
