### PR TITLE
py3 compatible README.rst parsing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
-
+import io
 from setuptools import setup
 
+
 def readme():
-    with open('README.rst') as f:
+    with io.open("README.rst", "r", encoding="utf8") as f:
         return f.read()
 
 setup(


### PR DESCRIPTION
Hit error `UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in
position 780: ordinal not in range(128)` on py3.

Tested this solution against python 3.6 and 2.7