### PR TITLE
fix get column names for repeated fields of type record

### DIFF
--- a/pybigquery/sqlalchemy_bigquery.py
+++ b/pybigquery/sqlalchemy_bigquery.py
@@ -311,16 +311,15 @@ class BigQueryDialect(DefaultDialect):
         """
         results = []
         for col in columns:
-            if col.field_type == 'RECORD' and col.mode != 'REPEATED':
+            results += [SchemaField(name='.'.join(col.name for col in cur_columns + [col]),
+                                    field_type=col.field_type,
+                                    mode=col.mode,
+                                    description=col.description,
+                                    fields=col.fields)]
+            if col.field_type == 'RECORD':
                 cur_columns.append(col)
                 results += self._get_columns_helper(col.fields, cur_columns)
                 cur_columns.pop()
-            else:
-                results += [SchemaField(name='.'.join(col.name for col in cur_columns + [col]),
-                                        field_type=col.field_type,
-                                        mode=col.mode,
-                                        description=col.description,
-                                        fields=col.fields)]
         return results
 
     def get_columns(self, connection, table_name, schema=None, **kw):

--- a/test/test_sqlalchemy_bigquery.py
+++ b/test/test_sqlalchemy_bigquery.py
@@ -25,8 +25,10 @@ ONE_ROW_CONTENTS_EXPANDED = [
     datetime.datetime(2013, 10, 10, 11, 27, 16),
     datetime.time(11, 27, 16),
     b'\xef',
+    {u'age': 100, u'name': u'John Doe'},
     'John Doe',
     100,
+    {u'record': {u'age': 200, u'name': u'John Doe 2'}}, {u'age': 200, u'name': u'John Doe 2'},
     'John Doe 2',
     200,
     [1, 2, 3],
@@ -77,8 +79,11 @@ SAMPLE_COLUMNS = [
     {'name': 'datetime', 'type': types.DATETIME(), 'nullable': True, 'default': None},
     {'name': 'time', 'type': types.TIME(), 'nullable': True, 'default': None},
     {'name': 'bytes', 'type': types.BINARY(), 'nullable': True, 'default': None},
+    {'name': 'record', 'type': types.JSON(), 'nullable': True, 'default': None},
     {'name': 'record.name', 'type': types.String(), 'nullable': True, 'default': None},
     {'name': 'record.age', 'type': types.Integer(), 'nullable': True, 'default': None},
+    {'name': 'nested_record', 'type': types.JSON(), 'nullable': True, 'default': None},
+    {'name': 'nested_record.record', 'type': types.JSON(), 'nullable': True, 'default': None},
     {'name': 'nested_record.record.name', 'type': types.String(), 'nullable': True, 'default': None},
     {'name': 'nested_record.record.age', 'type': types.Integer(), 'nullable': True, 'default': None},
     {'name': 'array', 'type': types.ARRAY(types.Integer()), 'nullable': True, 'default': None},
@@ -200,7 +205,7 @@ def test_dataset_location(engine_with_location):
 
 def test_reflect_select(table, table_using_test_dataset):
     for table in [table, table_using_test_dataset]:
-        assert len(table.c) == 14
+        assert len(table.c) == 17
 
         assert isinstance(table.c.integer, Column)
         assert isinstance(table.c.integer.type, types.Integer)


### PR DESCRIPTION
Currently, getColumns for repeated fields of type record only returns the top level column name.

Example, 
Instead of the returning something like,
```
array_field_name type:Record, mode:Repeated
array_field_name.foo : string
array_field_name.bar : string
```

getColumns() is returning 
```
array_field_name type:Record, mode:Repeated`
```

>> This PR is trying to address the above bug.

For type:record that is a non-repeated field, we will return something like this,
```
array_field_name type:Record, mode:NULLABLE
array_field_name.foo : string
array_field_name.bar : string
```

CC: @tswast @mistercrunch @mxmzdlv 
let me know if this is OK? 