### PR TITLE
return partition and clustering keys for tables through get_indexes

### DIFF
--- a/pybigquery/sqlalchemy_bigquery.py
+++ b/pybigquery/sqlalchemy_bigquery.py
@@ -355,13 +355,12 @@ class BigQueryDialect(DefaultDialect):
         indexes = []
         if table.time_partitioning:
             indexes.append({'name': 'partition',
-                            'column_names': table.time_partitioning.field,
+                            'column_names': [table.time_partitioning.field],
                             'unique': False})
         if table.clustering_fields:
-            for cluster_field in table.clustering_fields:
-                indexes.append({'name': 'clustering',
-                                'column_names': cluster_field,
-                                'unique': False})
+            indexes.append({'name': 'clustering',
+                            'column_names': table.clustering_fields,
+                            'unique': False})
         return indexes
 
     def get_schema_names(self, connection, **kw):

--- a/pybigquery/sqlalchemy_bigquery.py
+++ b/pybigquery/sqlalchemy_bigquery.py
@@ -351,8 +351,18 @@ class BigQueryDialect(DefaultDialect):
         return []
 
     def get_indexes(self, connection, table_name, schema=None, **kw):
-        # BigQuery has no support for indexes.
-        return []
+        table = self._get_table(connection, table_name, schema)
+        indexes = []
+        if table.time_partitioning:
+            indexes.append({'name': 'partition',
+                            'column_names': table.time_partitioning.field,
+                            'unique': False})
+        if table.clustering_fields:
+            for cluster_field in table.clustering_fields:
+                indexes.append({'name': 'clustering',
+                                'column_names': cluster_field,
+                                'unique': False})
+        return indexes
 
     def get_schema_names(self, connection, **kw):
         if isinstance(connection, Engine):

--- a/scripts/load_test_data.sh
+++ b/scripts/load_test_data.sh
@@ -6,7 +6,11 @@ bq rm -f -t test_pybigquery.sample_one_row
 bq rm -f -t test_pybigquery.sample_dml
 bq rm -f -t test_pybigquery_location.sample_one_row
 
+bq mk --table --schema=$(dirname $0)/schema.json --time_partitioning_field timestamp --clustering_fields integer,string test_pybigquery.sample
 bq load --source_format=NEWLINE_DELIMITED_JSON --schema=$(dirname $0)/schema.json test_pybigquery.sample $(dirname $0)/sample.json
+
+bq mk --table --schema=$(dirname $0)/schema.json --time_partitioning_field timestamp --clustering_fields integer,string test_pybigquery.sample_one_row
 bq load --source_format=NEWLINE_DELIMITED_JSON --schema=$(dirname $0)/schema.json test_pybigquery.sample_one_row $(dirname $0)/sample_one_row.json
+
 bq --location=asia-northeast1 load --source_format=NEWLINE_DELIMITED_JSON --schema=$(dirname $0)/schema.json test_pybigquery_location.sample_one_row $(dirname $0)/sample_one_row.json
 bq mk --schema=$(dirname $0)/schema.json -t test_pybigquery.sample_dml

--- a/test/test_sqlalchemy_bigquery.py
+++ b/test/test_sqlalchemy_bigquery.py
@@ -402,10 +402,9 @@ def test_table_names_in_schema(inspector, inspector_using_test_dataset):
 def test_get_indexes(inspector, inspector_using_test_dataset):
     for table in ['test_pybigquery.sample', 'test_pybigquery.sample_one_row']:
         indexes = inspector.get_indexes('test_pybigquery.sample')
-        assert len(indexes) == 3
-        assert indexes[0] == {'name':'partition', 'column_names': 'timestamp', 'unique': False}
-        assert indexes[1] == {'name': 'clustering', 'column_names': 'integer', 'unique': False}
-        assert indexes[2] == {'name': 'clustering', 'column_names': 'string', 'unique': False}
+        assert len(indexes) == 2
+        assert indexes[0] == {'name':'partition', 'column_names': ['timestamp'], 'unique': False}
+        assert indexes[1] == {'name': 'clustering', 'column_names': ['integer', 'string'], 'unique': False}
 
 
 def test_get_columns(inspector, inspector_using_test_dataset):

--- a/test/test_sqlalchemy_bigquery.py
+++ b/test/test_sqlalchemy_bigquery.py
@@ -399,6 +399,15 @@ def test_table_names_in_schema(inspector, inspector_using_test_dataset):
     assert len(tables) == 3
 
 
+def test_get_indexes(inspector, inspector_using_test_dataset):
+    for table in ['test_pybigquery.sample', 'test_pybigquery.sample_one_row']:
+        indexes = inspector.get_indexes('test_pybigquery.sample')
+        assert len(indexes) == 3
+        assert indexes[0] == {'name':'partition', 'column_names': 'timestamp', 'unique': False}
+        assert indexes[1] == {'name': 'clustering', 'column_names': 'integer', 'unique': False}
+        assert indexes[2] == {'name': 'clustering', 'column_names': 'string', 'unique': False}
+
+
 def test_get_columns(inspector, inspector_using_test_dataset):
     columns_without_schema = inspector.get_columns('test_pybigquery.sample')
     columns_schema = inspector.get_columns('sample', 'test_pybigquery')


### PR DESCRIPTION
pybigquery does not return information about partitioning / cluster key on a bigquery table. this PR adds that support. so consumers like superset can use this information.

CC: @mistercrunch @tswast @mxmzdlv 
