### PR TITLE
Add type compiler.

### DIFF
--- a/pybigquery/sqlalchemy_bigquery.py
+++ b/pybigquery/sqlalchemy_bigquery.py
@@ -12,7 +12,7 @@ from google.oauth2 import service_account
 from google.api_core.exceptions import NotFound
 from sqlalchemy.exc import NoSuchTableError
 from sqlalchemy import types, util
-from sqlalchemy.sql.compiler import SQLCompiler, IdentifierPreparer
+from sqlalchemy.sql.compiler import SQLCompiler, GenericTypeCompiler, IdentifierPreparer
 from sqlalchemy.engine.default import DefaultDialect, DefaultExecutionContext
 from sqlalchemy.engine.base import Engine
 from sqlalchemy.sql.schema import Column
@@ -179,11 +179,30 @@ class BigQueryCompiler(SQLCompiler):
         return result
 
 
+class BigQueryTypeCompiler(GenericTypeCompiler):
+
+    def visit_integer(self, type_, **kw):
+        return 'INT64'
+
+    def visit_float(self, type_, **kw):
+        return 'FLOAT64'
+
+    def visit_text(self, type_, **kw):
+        return 'STRING'
+
+    def visit_BINARY(self, type_, **kw):
+        return 'BYTES'
+
+    def visit_DECIMAL(self, type_, **kw):
+        return 'NUMERIC'
+
+
 class BigQueryDialect(DefaultDialect):
     name = 'bigquery'
     driver = 'bigquery'
     preparer = BigQueryIdentifierPreparer
     statement_compiler = BigQueryCompiler
+    type_compiler = BigQueryTypeCompiler
     execution_ctx_cls = BigQueryExecutionContext
     supports_alter = False
     supports_pk_autoincrement = False

--- a/pybigquery/sqlalchemy_bigquery.py
+++ b/pybigquery/sqlalchemy_bigquery.py
@@ -12,7 +12,7 @@ from google.oauth2 import service_account
 from google.api_core.exceptions import NotFound
 from sqlalchemy.exc import NoSuchTableError
 from sqlalchemy import types, util
-from sqlalchemy.sql.compiler import SQLCompiler, GenericTypeCompiler, IdentifierPreparer
+from sqlalchemy.sql.compiler import SQLCompiler, GenericTypeCompiler, DDLCompiler, IdentifierPreparer
 from sqlalchemy.engine.default import DefaultDialect, DefaultExecutionContext
 from sqlalchemy.engine.base import Engine
 from sqlalchemy.sql.schema import Column
@@ -197,12 +197,24 @@ class BigQueryTypeCompiler(GenericTypeCompiler):
         return 'NUMERIC'
 
 
+class BigQueryDDLCompiler(DDLCompiler):
+
+    # BigQuery has no support for foreign keys.
+    def visit_foreign_key_constraint(self, constraint):
+        return None
+
+    # BigQuery has no support for primary keys.
+    def visit_primary_key_constraint(self, constraint):
+        return None
+
+
 class BigQueryDialect(DefaultDialect):
     name = 'bigquery'
     driver = 'bigquery'
     preparer = BigQueryIdentifierPreparer
     statement_compiler = BigQueryCompiler
     type_compiler = BigQueryTypeCompiler
+    ddl_compiler = BigQueryDDLCompiler
     execution_ctx_cls = BigQueryExecutionContext
     supports_alter = False
     supports_pk_autoincrement = False

--- a/pybigquery/sqlalchemy_bigquery.py
+++ b/pybigquery/sqlalchemy_bigquery.py
@@ -190,6 +190,9 @@ class BigQueryTypeCompiler(GenericTypeCompiler):
     def visit_text(self, type_, **kw):
         return 'STRING'
 
+    def visit_string(self, type_, **kw):
+        return 'STRING'
+
     def visit_BINARY(self, type_, **kw):
         return 'BYTES'
 

--- a/scripts/load_test_data.sh
+++ b/scripts/load_test_data.sh
@@ -5,8 +5,6 @@ bq rm -f -t test_pybigquery.sample
 bq rm -f -t test_pybigquery.sample_one_row
 bq rm -f -t test_pybigquery.sample_dml
 bq rm -f -t test_pybigquery_location.sample_one_row
-bq rm -f -t test_pybigquery.test_table_create
-bq rm -f -t test_pybigquery.test_table_create2
 
 bq mk --table --schema=$(dirname $0)/schema.json --time_partitioning_field timestamp --clustering_fields integer,string test_pybigquery.sample
 bq load --source_format=NEWLINE_DELIMITED_JSON --schema=$(dirname $0)/schema.json test_pybigquery.sample $(dirname $0)/sample.json

--- a/scripts/load_test_data.sh
+++ b/scripts/load_test_data.sh
@@ -5,6 +5,8 @@ bq rm -f -t test_pybigquery.sample
 bq rm -f -t test_pybigquery.sample_one_row
 bq rm -f -t test_pybigquery.sample_dml
 bq rm -f -t test_pybigquery_location.sample_one_row
+bq rm -f -t test_pybigquery.test_table_create
+bq rm -f -t test_pybigquery.test_table_create2
 
 bq mk --table --schema=$(dirname $0)/schema.json --time_partitioning_field timestamp --clustering_fields integer,string test_pybigquery.sample
 bq load --source_format=NEWLINE_DELIMITED_JSON --schema=$(dirname $0)/schema.json test_pybigquery.sample $(dirname $0)/sample.json

--- a/test/test_sqlalchemy_bigquery.py
+++ b/test/test_sqlalchemy_bigquery.py
@@ -383,16 +383,31 @@ def test_dml(engine, session, table_dml):
     assert len(result) == 0
 
 
-def test_create_table(engine, session):
+def test_create_table(engine):
+    meta = MetaData()
+    table = Table(
+        'test_pybigquery.test_table_create', meta,
+        Column('integer_c', sqlalchemy.Integer),
+        Column('float_c', sqlalchemy.Float),
+        Column('decimal_c', sqlalchemy.DECIMAL),
+        Column('string_c', sqlalchemy.String),
+        Column('text_c', sqlalchemy.Text),
+        Column('boolean_c', sqlalchemy.Boolean),
+        Column('timestamp_c', sqlalchemy.TIMESTAMP),
+        Column('datetime_c', sqlalchemy.DATETIME),
+        Column('date_c', sqlalchemy.DATE),
+        Column('time_c', sqlalchemy.TIME),
+        Column('binary_c', sqlalchemy.BINARY)
+    )
+    meta.create_all(engine)
+
+    # Test creating tables with declarative_base
     Base = declarative_base()
 
-    class Table(Base):
-        __tablename__ = 'test_pybigquery.test_table_create'
-        integer_c = Column(sqlalchemy.Integer)
+    class TableTest(Base):
+        __tablename__ = 'test_pybigquery.test_table_create2'
+        integer_c = Column(sqlalchemy.Integer, primary_key=True)
         float_c = Column(sqlalchemy.Float)
-        text_c = Column(sqlalchemy.Text)
-        binary_c = Column(sqlalchemy.BINARY)
-        decimal_c = Column(sqlalchemy.DECIMAL)
 
     Base.metadata.create_all(engine)
 

--- a/test/test_sqlalchemy_bigquery.py
+++ b/test/test_sqlalchemy_bigquery.py
@@ -5,6 +5,7 @@ from google.api_core.exceptions import BadRequest
 from pybigquery.api import ApiClient
 from sqlalchemy.engine import create_engine
 from sqlalchemy.schema import Table, MetaData, Column
+from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import types, func, case, inspect
 from sqlalchemy.sql import expression, select, literal_column
 from sqlalchemy.exc import NoSuchTableError
@@ -380,6 +381,20 @@ def test_dml(engine, session, table_dml):
     session.query(table_dml).filter(table_dml.c.string == 'updated_row').delete(synchronize_session=False)
     result = table_dml.select().execute().fetchall()
     assert len(result) == 0
+
+
+def test_create_table(engine, session):
+    Base = declarative_base()
+
+    class Table(Base):
+        __tablename__ = 'test_pybigquery.test_table_create'
+        integer_c = Column(sqlalchemy.Integer)
+        float_c = Column(sqlalchemy.Float)
+        text_c = Column(sqlalchemy.Text)
+        binary_c = Column(sqlalchemy.BINARY)
+        decimal_c = Column(sqlalchemy.DECIMAL)
+
+    Base.metadata.create_all(engine)
 
 
 def test_schemas_names(inspector, inspector_using_test_dataset):

--- a/test/test_sqlalchemy_bigquery.py
+++ b/test/test_sqlalchemy_bigquery.py
@@ -400,6 +400,7 @@ def test_create_table(engine):
         Column('binary_c', sqlalchemy.BINARY)
     )
     meta.create_all(engine)
+    meta.drop_all(engine)
 
     # Test creating tables with declarative_base
     Base = declarative_base()
@@ -410,7 +411,7 @@ def test_create_table(engine):
         float_c = Column(sqlalchemy.Float)
 
     Base.metadata.create_all(engine)
-
+    Base.metadata.drop_all(engine)
 
 def test_schemas_names(inspector, inspector_using_test_dataset):
     datasets = inspector.get_schema_names()


### PR DESCRIPTION
Map generic datatypes to bigquery datatypes.

With this patch, I was able to create tables with common types via pybigquery.