### PR TITLE
Support table and column metadata.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -128,6 +128,20 @@ Here are examples of all the supported arguments. Any not present are either for
     )
 
 
+Creating tables
+_______________
+
+To add metadata to a table:
+
+.. code-block:: python
+    table = Table('mytable', ..., bigquery_description='my table description', bigquery_friendly_name='my table friendly name')
+
+To add metadata to a column:
+
+.. code-block:: python
+    Column('mycolumn', doc='my column description')
+
+
 Requirements
 ============
 

--- a/README.rst
+++ b/README.rst
@@ -134,11 +134,13 @@ _______________
 To add metadata to a table:
 
 .. code-block:: python
+
     table = Table('mytable', ..., bigquery_description='my table description', bigquery_friendly_name='my table friendly name')
 
 To add metadata to a column:
 
 .. code-block:: python
+
     Column('mycolumn', doc='my column description')
 
 

--- a/pybigquery/sqlalchemy_bigquery.py
+++ b/pybigquery/sqlalchemy_bigquery.py
@@ -210,6 +210,23 @@ class BigQueryDDLCompiler(DDLCompiler):
     def visit_primary_key_constraint(self, constraint):
         return None
 
+    def get_column_specification(self, column, **kwargs):
+        colspec = super(BigQueryDDLCompiler, self).get_column_specification(column, **kwargs)
+        if column.doc is not None:
+            colspec = '{} OPTIONS(description={})'.format(colspec, self.preparer.quote(column.doc))
+        return colspec
+
+    def post_create_table(self, table):
+        bq_opts = table.dialect_options['bigquery']
+        opts = []
+        if 'description' in bq_opts:
+            opts.append('description={}'.format(self.preparer.quote(bq_opts['description'])))
+        if 'friendly_name' in bq_opts:
+            opts.append('friendly_name={}'.format(self.preparer.quote(bq_opts['friendly_name'])))
+        if opts:
+            return '\nOPTIONS({})'.format(', '.join(opts))
+        return ''
+
 
 class BigQueryDialect(DefaultDialect):
     name = 'bigquery'

--- a/test/test_sqlalchemy_bigquery.py
+++ b/test/test_sqlalchemy_bigquery.py
@@ -387,7 +387,7 @@ def test_create_table(engine):
     meta = MetaData()
     table = Table(
         'test_pybigquery.test_table_create', meta,
-        Column('integer_c', sqlalchemy.Integer),
+        Column('integer_c', sqlalchemy.Integer, doc="column description"),
         Column('float_c', sqlalchemy.Float),
         Column('decimal_c', sqlalchemy.DECIMAL),
         Column('string_c', sqlalchemy.String),
@@ -397,7 +397,9 @@ def test_create_table(engine):
         Column('datetime_c', sqlalchemy.DATETIME),
         Column('date_c', sqlalchemy.DATE),
         Column('time_c', sqlalchemy.TIME),
-        Column('binary_c', sqlalchemy.BINARY)
+        Column('binary_c', sqlalchemy.BINARY),
+        bigquery_description="test table description",
+        bigquery_friendly_name="test table name"
     )
     meta.create_all(engine)
     meta.drop_all(engine)


### PR DESCRIPTION
To add metadata to a table:

```python
table = Table('mytable', ..., bigquery_description='my table description')
```

To add metadata to a column:

```python
Column('mycolumn', doc='my column description')
```