### PR TITLE
Fix NUMERIC DDL representation.

### DIFF
--- a/pybigquery/sqlalchemy_bigquery.py
+++ b/pybigquery/sqlalchemy_bigquery.py
@@ -197,6 +197,9 @@ class BigQueryTypeCompiler(GenericTypeCompiler):
     def visit_BINARY(self, type_, **kw):
         return 'BYTES'
 
+    def visit_NUMERIC(self, type_, **kw):
+        return 'NUMERIC'
+
     def visit_DECIMAL(self, type_, **kw):
         return 'NUMERIC'
 


### PR DESCRIPTION
BigQuery NUMERIC types don't have configurable scale or precision, so
override the default visitor to drop unused arguments.