### PR TITLE
Fix visit_label override to handle nested labels

### DIFF
--- a/pybigquery/sqlalchemy_bigquery.py
+++ b/pybigquery/sqlalchemy_bigquery.py
@@ -183,12 +183,17 @@ class BigQueryCompiler(SQLCompiler):
                 self.preparer.quote(tablename) + \
                 "." + name
 
-    def visit_label(self, *args, **kwargs):
-        # Use labels in GROUP BY clause
-        if len(kwargs) == 0 or len(kwargs) == 1:
+    def visit_label(self, *args, within_group_by=False, **kwargs):
+        # Use labels in GROUP BY clause.
+        #
+        # Flag set in the group_by_clause method. Works around missing equivalent to
+        # supports_simple_order_by_label for group by.
+        if within_group_by:
             kwargs['render_label_as_label'] = args[0]
-        result = super(BigQueryCompiler, self).visit_label(*args, **kwargs)
-        return result
+        return super(BigQueryCompiler, self).visit_label(*args, **kwargs)
+
+    def group_by_clause(self, select, **kw):
+        return super(BigQueryCompiler, self).group_by_clause(select, **kw, within_group_by=True)
 
 
 class BigQueryTypeCompiler(GenericTypeCompiler):

--- a/pybigquery/sqlalchemy_bigquery.py
+++ b/pybigquery/sqlalchemy_bigquery.py
@@ -186,14 +186,16 @@ class BigQueryCompiler(SQLCompiler):
     def visit_label(self, *args, within_group_by=False, **kwargs):
         # Use labels in GROUP BY clause.
         #
-        # Flag set in the group_by_clause method. Works around missing equivalent to
-        # supports_simple_order_by_label for group by.
+        # Flag set in the group_by_clause method. Works around missing
+        # equivalent to supports_simple_order_by_label for group by.
         if within_group_by:
             kwargs['render_label_as_label'] = args[0]
         return super(BigQueryCompiler, self).visit_label(*args, **kwargs)
 
     def group_by_clause(self, select, **kw):
-        return super(BigQueryCompiler, self).group_by_clause(select, **kw, within_group_by=True)
+        return super(BigQueryCompiler, self).group_by_clause(
+            select, **kw, within_group_by=True
+        )
 
 
 class BigQueryTypeCompiler(GenericTypeCompiler):

--- a/test/test_sqlalchemy_bigquery.py
+++ b/test/test_sqlalchemy_bigquery.py
@@ -162,10 +162,14 @@ def query():
     def query(table):
         col1 = literal_column("TIMESTAMP_TRUNC(timestamp, DAY)").label("timestamp_label")
         col2 = func.sum(table.c.integer)
+        # Test rendering of nested labels. Full expression should render in SELECT, but
+        # ORDER/GROUP BY should use label only.
+        col3 = func.sum(func.sum(table.c.integer.label("inner")).label("outer")).over().label('outer')
         query = (
             select([
                 col1,
                 col2,
+                col3,
             ])
             .where(col1 < '2017-01-01 00:00:00')
             .group_by(col1)


### PR DESCRIPTION
Fixes #39 - passes the "test case" I posted there and a number of internal queries I've tested with. Will look into adding a formal test in the next few days.

```
Print:
SELECT sum(sum(`test`.`val`)) OVER () AS `anon_1`, sum(CASE WHEN %(param_1)s THEN `test`.`val` END) AS `sum_1`, sum(sum(CASE WHEN %(param_2)s THEN `test`.`val` END)) OVER () AS `anon_2`
FROM `test`

Compile:
SELECT sum(sum(`test`.`val`)) OVER () AS `anon_1`, sum(CASE WHEN %(param_1)s THEN `test`.`val` END) AS `sum_1`, sum(sum(CASE WHEN %(param_2)s THEN `test`.`val` END)) OVER () AS `anon_2`
FROM `test`

Literal compile:
SELECT sum(sum(`test`.`val`)) OVER () AS `anon_1`, sum(CASE WHEN true THEN `test`.`val` END) AS `sum_1`, sum(sum(CASE WHEN true THEN `test`.`val` END)) OVER () AS `anon_2`
FROM `test`

Result:
((6, 6, 6),)
```

I haven't noticed any regressions with expressions in the group by. That seems to be fully supported by BQ anyway, so I'm guessing the method I removed was just for nicer looking "group by" statements? I'll try to break this a bit more, but would love some other insight there.