### PR TITLE
Set BigQueryDialect.supports_multiline_insert to True

### DIFF
--- a/pybigquery/sqlalchemy_bigquery.py
+++ b/pybigquery/sqlalchemy_bigquery.py
@@ -244,6 +244,7 @@ class BigQueryDialect(DefaultDialect):
     supports_pk_autoincrement = False
     supports_default_values = False
     supports_empty_insert = False
+    supports_multiline_insert = True
     supports_unicode_statements = True
     supports_unicode_binds = True
     supports_native_decimal = True


### PR DESCRIPTION
The default sqlalchemy `visit_insert` [compiler method](https://github.com/sqlalchemy/sqlalchemy/blob/5675345fc11966d449130ff4e4327a5a4bece0c2/lib/sqlalchemy/sql/compiler.py#L2828) compiles a correct BigQuery INSERT statement mostly out-of-the-box, it just needs to have this flag enabled.