### PR TITLE
Update README.rst to fix typo: "SQLAchemy" -> "SQLAlchemy"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ Usage
 =====
 
 
-SQLAchemy
+SQLAlchemy
 _________
 
 .. code-block:: python

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ Usage
 
 
 SQLAlchemy
-_________
+__________
 
 .. code-block:: python
 


### PR DESCRIPTION
fix typo: "SQLAchemy" -> "SQLAlchemy"